### PR TITLE
feat: Receive messages continually on server and network in while loop

### DIFF
--- a/server.py
+++ b/server.py
@@ -10,7 +10,9 @@ from connect4 import Connect4Game
 
 connect4game = Connect4Game()
 
-lock = threading.Lock()
+
+to_shuffle = threading.Event()
+to_shuffle.set()
 
 clients: List = []
 players: List = []
@@ -18,7 +20,7 @@ players: List = []
 
 class Connect4TerminalPlusSocket:
     def __init__(self):
-        self.HEADER = 64
+        self.HEADERSIZE = 10
         # SERVER = socket.gethostbyname(socket.gethostname())
         self.SERVER = "127.0.0.1"
         self.PORT = 5050
@@ -35,39 +37,61 @@ class Connect4TerminalPlusSocket:
         else:
             self.start()
 
+    def send_data(self, conn, data):
+        data = pickle.dumps(data)
+        data = bytes(f'{len(data):<{self.HEADERSIZE}}', self.FORMAT) + data
+        conn.send(data)
+
+
     def start(self):
         global clients
         print("[STARTING] server is starting...")
         self.server.listen(2)
         print(f"[LISTENING] Server is listening on {self.SERVER}")
+        thread = threading.Thread(target=self.start_game_when_two_clients)
+        thread.start()
+
+        i = 1
         while True:
             conn, addr = self.server.accept()
             clients.append((conn, addr))
-            thread = threading.Thread(target=self.start_game_when_two_clients, args=(conn, addr))
-            thread.start()
+
+            print(f"[ACTIVE CONNECTIONS] {i}")
+            i += 1
             
-            print(f"[ACTIVE CONNECTIONS] {threading.activeCount() - 1}")
         
-    def start_game_when_two_clients(self, conn, addr):
-        with lock:
-            global clients
-            clients = copy.copy(clients)
+    def start_game_when_two_clients(self):
+        global clients
+        i = 0
+        lock = threading.Lock()
 
-        if len(clients) == 1:
-            print("Waiting for other player to join the connection")
-            while len(clients) != 2:
+        while True:
+            if len(clients) == 1:
+                if i == 0:
+                    print("Waiting for other player to join the connection")
                 time.sleep(5)
-                
+                i += 1
+                continue
+                    
+            # TODO: Close conn if no other client joins connection after specified time
+            # elif len(clients) == 1:
+            #     print("Connection timed out. No other player joined the game")
+            #     self.reset_client()
 
-        if len(clients) == 1:
-            print("Connection timed out. No other player joined the game")
-            self.reset_client()
-        elif len(clients) == 2:
-            print("Both clients connected. Starting game. . .")
-            for client in clients:
-                conn, addr = client
-                thread = threading.Thread(target=self.play_game, args=(conn, addr))
-                thread.start()
+            elif len(clients) == 2:            
+                print("Both clients connected. Starting game. . .")
+                for client in clients:
+                    conn, addr = client
+                    thread = threading.Thread(target=self.get_player_names, args=(conn, addr, lock))
+                    thread.start()
+                    thread.join()
+
+                for client in clients:
+                    conn, addr = client
+                    thread = threading.Thread(target=self.play_game, args=(conn, addr, lock))
+                    thread.start()
+                break
+            
 
     def reset_client(self, conn, addr):
         global clients
@@ -76,37 +100,93 @@ class Connect4TerminalPlusSocket:
         self.conn.close()
                 
 
-    def play_game(self, conn, addr):
-        with lock:
-            global clients
-            clients = copy.copy(clients)
+    def get_player_names(self, conn, addr, lock):
+        print("Player names thread running. . . ")
+        global players
 
         print(f"[NEW CONNECTION] {addr} connected.")
-        conn.send(str.encode("CONNECTED"))
         
+        self.send_data(conn, {"connected":"True"})
+
+        full_msg = b''
+        new_msg = True
         while True:
-            conn1, _ = clients[0]
-            conn2, _ = clients[1]
+            msg = conn.recv(16)        
+            if new_msg:
+                msglen = int(msg[:self.HEADERSIZE])
+                new_msg = False
 
-            you = msg = conn.recv(2048).decode(self.FORMAT)
-            opponent = ''
-            
-            if conn1 == conn:
-                conn2.send(str.encode(you))
-            else:
-                conn1.send(str.encode(you))
-            # conn.send(str.encode("Waiting for other player to join. . ."))
-            
-            shuffled_players = connect4game._shuffle_players([you, opponent])
 
-            conn.sendall(pickle.dumps(shuffled_players))    
+            full_msg += msg
 
-            if msg:
-                if msg == self.DISCONNECT_MESSAGE:
+            if len(full_msg)-self.HEADERSIZE == msglen:
+                # ----------------Use loaded json data here----------------
+
+                loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])
+                print("loaded_json: ",  loaded_json)
+                new_msg = True
+                full_msg = b''     
+                try:
+                    if 'you' in loaded_json:
+                        you = loaded_json['you']
+                        
+                        lock.acquire()
+                        players.append(you)
+                        lock.release()
+
+                        break                    
+                    elif 'DISCONNECT' in loaded_json:
+                        if loaded_json['DISCONNECT'] == self.DISCONNECT_MESSAGE:                            
+                            self.reset_client(conn, addr)                            
+                except KeyError:
+                    self.reset_client(conn, addr)                          
+
+                    # ----------------Use loaded json data here---------------- 
+
+
+
+
+    def play_game(self, conn, addr, lock):
+        print("play game thread running. . . ")
+        global players
+        global clients
+        
+        with lock:
+            clients = copy.copy(clients)
+            players = copy.copy(players)
+        
+        self.send_data(conn, {"players":players})
+        
+        conn1, _ = clients[0]
+        conn2, _ = clients[1]
+
+        full_msg = b''
+        new_msg = True
+        while True:
+            msg = conn.recv(16)        
+            if new_msg:
+                msglen = int(msg[:self.HEADERSIZE])
+                new_msg = False
+
+
+            full_msg += msg
+
+            if len(full_msg)-self.HEADERSIZE == msglen:
+                # ----------------Use loaded json data here----------------
+
+                loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])
+                print("loaded_json: ",  loaded_json)
+                new_msg = True
+                full_msg = b''     
+                try:                    
+                    if 'DISCONNECT' in loaded_json:
+                        if loaded_json['DISCONNECT'] == self.DISCONNECT_MESSAGE:                            
+                            break
+                except KeyError:                
                     break
-            else:
-                print("Disconnected")
-                break
+
+                    # ----------------Use loaded json data here----------------   
+
 
         self.reset_client(conn, addr)
         


### PR DESCRIPTION
- Continually append msg until full msg is recieved
- Use threading.join() to get players' names one at a time and only continue when both names are gotten
- Make thread that checks for client a single thread - remove it from the loop
- Send messages in dictionary/json format with keys that describe messages to know which action to take instead of using strings and startswith
- Calculate active connections with number of times loop has run instead of number of active threads
- Include length of messages in messages before sending and use same length to receive the messages