### PR TITLE
feat: Timeout server after some time if no client joins the conn or if only one client is left in the conn

### DIFF
--- a/client.py
+++ b/client.py
@@ -19,7 +19,7 @@ connect4game = Connect4Game()
 
 
 
-class Network:
+class Client:
     FORMAT = 'utf-8'
     DISCONNECT_MESSAGE = "!DISCONNECT"
     POINTS_FOR_WINNING_ONE_ROUND = 10
@@ -235,7 +235,7 @@ class Network:
                 # NOTE Calling .join on self.loading_thread ensures that the spinner function has completed 
                 # NOTE (and finished using stdout) before attempting to print anything else to stdout.
                 # NOTE The first time .join is called, it joins the self.loading_thread instantiated 
-                # NOTE and started in the init function of the Network class.
+                # NOTE and started in the init function of the Client class.
 
                 # ! .join must be called on loading_thread only after loaded pickle of full_msg is assigned to self.loaded_json.
                 # ! Otherwise, condition for termination of spinner is never met
@@ -310,9 +310,9 @@ class Network:
                     self.send_data({'DISCONNECT':self.DISCONNECT_MESSAGE})                   
                     break
 
-        
+        main_game_thread.join() #  Wait for main_game_thread thread to end before printing
         print("Disconnected")
                     # ----------------Use loaded json data here----------------
 
 if __name__ == "__main__":
-    n = Network()
+    client = Client()

--- a/server.py
+++ b/server.py
@@ -18,7 +18,7 @@ clients: List = []
 players: List = []
 
 
-class Connect4TerminalPlusSocket:
+class Server:
     def __init__(self):
         self.HEADERSIZE = 10
         # self.SERVER = socket.gethostbyname(socket.gethostname())
@@ -195,5 +195,5 @@ class Connect4TerminalPlusSocket:
 
         
 if __name__ == "__main__":
-    connect4_terminal_plus_socket = Connect4TerminalPlusSocket()
-    connect4_terminal_plus_socket.host_game()
+    server = Server()
+    server.host_game()

--- a/server.py
+++ b/server.py
@@ -28,6 +28,8 @@ class Server:
         self.FORMAT = 'utf-8'
         self.DISCONNECT_MESSAGE = "!DISCONNECT"
         self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        self.TIMEOUT_FOR_SERVER = 10
         
 
     def host_game(self):
@@ -52,33 +54,45 @@ class Server:
         threading.Thread(target=self.start_game_when_two_clients).start()
 
         while True:
-            conn, addr = self.server.accept()
+            try:
+                conn, addr = self.server.accept()
+            except OSError:
+                break
             clients.append((conn, addr))
 
             print(f"[ACTIVE CONNECTIONS] {len(clients)}")
+        print("[CLOSED] server is closed")
             
         
     def start_game_when_two_clients(self):
         global clients
         
+        start_time = time.time()
+
         first_time = True
         lock = threading.Lock()
 
         while True:
-            if len(clients) == 1:
+            if not clients:
+                if time.time() > start_time + self.TIMEOUT_FOR_SERVER:
+                    print("Connection timed out: No client joined the connection. Try restarting the server.")
+                    self.server.close()
+                    break
+                time.sleep(1)
+                continue
+            elif len(clients) == 1:
                 if first_time:
                     print("Waiting for other player to join the connection. . .")
                     conn, _ = clients[0]
                     self.send_data(conn, {"status":"Waiting for other player to join the connection"})
+                if time.time() > start_time + self.TIMEOUT_FOR_SERVER:
+                    print("Connection timed out: No other player joined the game. Try restarting the server.")
+                    self.send_data(conn, {"timeout":"Connection timed out: No other player joined the game. Try restarting the server."})
+                    self.server.close()
+                    break
                 time.sleep(1)
                 first_time = False
                 continue
-                    
-            # TODO: Close conn if no other client joins connection after specified time
-            # elif len(clients) == 1:
-            #     print("Connection timed out. No other player joined the game")
-            #     self.reset_client()
-
             elif len(clients) == 2: 
                 id = 0           
                 print("Both clients connected. Starting game. . .")


### PR DESCRIPTION
- Wait for main_game_thread to end before continuing in play_game thread, join main_game_thread to play_game thread only if game_over_event is set, otherwise, it would be referencing the main_game_thread variable before assignment.
- Rename Connect4TerminalPlusSocket to Server (refactor)
- Timeout server after some time if no client joins the conn or if only one client is left in the conn
- Catch OSError exception after closing server in order to break out of forever loop that accepts connections
- Rename connect to connect_to_game to make it descriptive and so that it is not confused with the connect method of built-in socket class (refactor)