### PR TITLE
feat: Handle server.py closing unexpectedly in client.py and pluralize 'round' if self.level.current_level is greater than 1

### DIFF
--- a/client.py
+++ b/client.py
@@ -35,7 +35,13 @@ class Client:
         
 
         self.HEADERSIZE = 10
-        self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        try:
+            self.client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except socket.error as e:
+            print(f"Error creating socket: {e}")
+            self.client = None
+
         self.server = "127.0.0.1"
         self.port = 5050
         self.addr = (self.server, self.port)
@@ -43,7 +49,7 @@ class Client:
         self.loading_thread = Thread()
         self.loaded_json = {}
 
-        self.new_msg_received = Event()
+        self.end_thread_event = Event()
         self.board_updated_event = Event() 
         self.play_again_reply_received = Event() 
         self.first_player_received = Event() 
@@ -59,9 +65,17 @@ class Client:
     def connect_to_game(self):
         try:
             self.client.connect(self.addr)
-        except Exception as e:
-            print(f"Connection failed: {e}")
+        except socket.gaierror as e:
+            print(f"Address-related error connecting to server: {e}")
+        except socket.error as e:
+            print(f"Connection error: {e}")
+            self.client.close()
+            self.client = None
         else:
+            if self.client is None:
+                print('Could not open socket')
+                sys.exit(1)
+
             self.loading_thread.daemon = True
             self.loading_thread.start()
             Thread(target=self.play_game).start()
@@ -69,7 +83,11 @@ class Client:
     def send_data(self, data):
         data = pickle.dumps(data)
         data = bytes(f'{len(data):<{self.HEADERSIZE}}', self.FORMAT) + data
-        self.client.send(data)
+        try:
+            self.client.send(data)
+        except socket.error:
+            raise
+
 
     def _get_other_player_name(self, player):
 
@@ -84,22 +102,22 @@ class Client:
 
         return other_player
 
-    def simulate_loading_with_spinner(self, loading_msg):
+    def simulate_loading_with_spinner(self, loading_msg, loaded_json):
         NO_OF_CHARACTERS_AFTER_LOADING_MSG = 5
         spaces_to_replace_spinner = ' ' * NO_OF_CHARACTERS_AFTER_LOADING_MSG
 
         def color_final_loading_msg():
             if type(loading_msg) == list:                
-                if 'other_client_disconnected' in self.loaded_json or 'timeout' in self.loaded_json:
+                if ('other_client_disconnected' in self.loaded_json or 'timeout' in self.loaded_json) or self.end_thread_event.is_set():
                     red_first_part = colored(loading_msg[0], "red", attrs=['bold'])
                     red_last_part = colored(loading_msg[2], "red", attrs=['bold'])
-                    final_loading_msg = f"{red_first_part}{loading_msg[1]}{red_last_part}"
+                    final_loading_msg = f"{red_first_part}{loading_msg[1]}{red_last_part}"                
                 else:
                     green_first_part = colored(loading_msg[0], "green", attrs=['bold'])
                     green_last_part = colored(loading_msg[2], "green", attrs=['bold'])
                     final_loading_msg = f"{green_first_part}{loading_msg[1]}{green_last_part}"
             else:
-                if 'other_client_disconnected' in self.loaded_json or 'timeout' in self.loaded_json:
+                if ('other_client_disconnected' in self.loaded_json or 'timeout' in self.loaded_json) or self.end_thread_event.is_set():
                     final_loading_msg = colored(loading_msg, "red", attrs=['bold'])
                 else:
                     final_loading_msg = colored(loading_msg, "green", attrs=['bold'])
@@ -113,8 +131,8 @@ class Client:
             yellow_loading_msg = colored(loading_msg, "yellow", attrs=['bold'])
             
                 
-        for c in itertools.cycle(['|', '/', '-', '\\']):
-            if self.new_msg_received.is_set():
+        for c in itertools.cycle(['|', '/', '-', '\\']):         
+            if loaded_json != self.loaded_json or self.end_thread_event.is_set():
                 sys.stdout.write(f'\r{color_final_loading_msg()}{spaces_to_replace_spinner}')
                 print("\n")
                 break
@@ -137,8 +155,8 @@ class Client:
             connect4game._calculate_and_display_final_result([self.player, self.opponent])
             print("Thanks for playing\n")
 
-    def _wait_for_two_events(self, some_event):
-        while not (some_event.is_set() or self.other_client_disconnected.is_set()):            
+    def _wait_for_one_of_multiple_events(self, some_event):
+        while not (some_event.is_set() or self.other_client_disconnected.is_set() or self.end_thread_event.is_set()):            
             with self.condition:
                 self.condition.wait()
         if some_event.is_set():
@@ -147,6 +165,32 @@ class Client:
         elif self.other_client_disconnected.is_set():
             self.other_client_disconnected.clear()            
             return True
+        elif self.end_thread_event.is_set():
+            return True
+
+    def _set_up_to_terminate_program(self, error_msg, main_game_thread=None, main_game_started=False):
+        if not self.end_thread_event.is_set(): #  print game stats and error msg only if one hasn't been printed before
+            
+            self.end_thread_event.set()
+            self.loading_thread.join()
+            with self.condition:
+                self.condition.notify()
+            if main_game_thread is not None:
+                main_game_thread.join()
+
+            # Print game stats
+            if not self.game_ended.is_set() and not self.game_over_event.is_set():
+                # If one of the conditions are satisfied, player objects have non-empty values and can be safely accessed 
+                # in _print_result() function. Also, there's no need to print results if the round did not start at all
+                if main_game_started:                                             
+                    self._print_result("round")
+                    self._print_result("game")
+                elif main_game_thread is None:       
+                    self._print_result("round")
+                    self._print_result("game")
+
+            print(f"\n{error_msg}\n")
+
 
     def main_game_thread(self):
         playing = True
@@ -161,8 +205,8 @@ class Client:
                 if self.your_turn:
 
                     if not first_time: #  Do not wait on first run of loop for board to be updated since no move has been made yet                        
-                        # Wait until board is updated with other player's latest move or until other_client_disconnected event is set
-                        if self._wait_for_two_events(self.board_updated_event): #  Other client has disconnected
+                        # Wait until board is updated with other player's latest move or until other_client_disconnected event is set or until end_thread_event is set
+                        if self._wait_for_one_of_multiple_events(self.board_updated_event): #  Other client has disconnected or end_thread_event is set
                             playing = False
                             return  #  "return" is used instead of "break" so that the play_again loop will not run
                         self.board.print_board() #  Print board to show player their opponent's move
@@ -177,19 +221,39 @@ class Client:
                         break
 
                     self.board.play_at_position(self.player)
+
+                    try:
+                        self.send_data({'board':self.board})
+                    except socket.error as e:
+                        error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                        self._set_up_to_terminate_program(error_msg)
+                        playing = False
+                        return 
+
                     self.board.print_board()
                     self.your_turn = False
-                    self.send_data({'board':self.board})
 
                     if self.board.check_win(self.player):
                         self.player.points += self.POINTS_FOR_WINNING_ONE_ROUND
                         print(f"\n{self.player.name} {self.player.marker} wins this round!\n")
-                        self.send_data({'round_over':True, 'winner':self.player})
+                        try:
+                            self.send_data({'round_over':True, 'winner':self.player})
+                        except socket.error as e:
+                            error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                            self._set_up_to_terminate_program(error_msg)
+                            playing = False
+                            return                        
                         break
 
                     if self.board.check_tie():
                         print("\nIt's a tie!\n")
-                        self.send_data({'round_over':True, 'winner':None})
+                        try:
+                            self.send_data({'round_over':True, 'winner':None})
+                        except socket.error as e:
+                            error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                            self._set_up_to_terminate_program(error_msg)
+                            playing = False
+                            return
                         break
 
                 else:                    
@@ -197,29 +261,35 @@ class Client:
                     # If raw string is entered directly, text after the marker does not get coloured.
                     loading_msg = [f"Waiting for {self.opponent.name} ", self.opponent.marker, " to play"]
                     self.your_turn = True
-                    self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg,))
+                    self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg, self.loaded_json, ))
                     self.loading_thread.start()
                 first_time = False
 
             self._print_result("round")
 
             while True:
-                if self.other_client_disconnected.is_set(): # Checks if opponent disconnected in the first run of this loop or after client entered a reply that was neither 'y' nor 'n'
+                if self.other_client_disconnected.is_set() or self.end_thread_event.is_set(): # Checks if opponent disconnected in the first run of this loop or after client entered a reply that was neither 'y' nor 'n'
                     playing = False
                     break
 
                 play_again = input("Want to play another round? Choosing 'no' will end the game and close this connection. \nEnter 'Y' for 'yes' and 'N' for 'no': ").lower().strip()
                 if play_again == 'y':
                     # Shuffle the players again before starting next round.
-                    self.send_data({'play_again':True})
+                    try:
+                        self.send_data({'play_again':True})
+                    except socket.error as e:
+                        error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                        self._set_up_to_terminate_program(error_msg)
+                        playing = False
+                        return
 
                     if 'play_again' not in self.loaded_json and 'other_client_disconnected' not in self.loaded_json:
                         loading_msg = f"Waiting for {self.opponent.name} to reply"
-                        self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg,))
+                        self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg, self.loaded_json, ))
                         self.loading_thread.start()
 
-                    # Wait until opponent replies or until other_client_disconnected event is set
-                    if self._wait_for_two_events(self.play_again_reply_received):  #  Other client has disconnected
+                    # Wait until opponent replies or until other_client_disconnected event is set or until end_thread_event is set
+                    if self._wait_for_one_of_multiple_events(self.play_again_reply_received):  #  Other client has disconnected or end_thread_event is set
                         playing = False
                         break
                     
@@ -228,10 +298,16 @@ class Client:
 
                         if not self.ID:
                             first_player = connect4game._shuffle_players([self.player, self.opponent])[0]
-                            self.send_data({'first_player':first_player})
+                            try:
+                                self.send_data({'first_player':first_player})
+                            except socket.error as e:
+                                error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                                self._set_up_to_terminate_program(error_msg)
+                                playing = False
+                                return
 
-                        # Wait until first player is received or until other_client_disconnected event is set
-                        if self._wait_for_two_events(self.first_player_received):  #  Other client has disconnected
+                        # Wait until first player is received or until other_client_disconnected event is set or until end_thread_event is set
+                        if self._wait_for_one_of_multiple_events(self.first_player_received):  #  Other client has disconnected or end_thread_event is set
                             playing = False
                             break                
 
@@ -245,17 +321,29 @@ class Client:
                         break
                     else:
                         # Opponent does not want to play another round
+                        self.game_ended.set()
                         print(f"{self.opponent.name} has quit")
                         self._print_result("game")
-                        self.send_data({'wait_for_new_client':True})                        
-                        self.game_ended.set()
+                        try:
+                            self.send_data({'wait_for_new_client':True})
+                        except socket.error as e:
+                            error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                            # Unlike other places where this funciton is called, loop is not terminated immediately
+                            # because it will terminate anyway, and so that it will end naturally like when opponent quits 
+                            self._set_up_to_terminate_program(error_msg)
+
                         playing = False
                         break
                 elif play_again == 'n':
-                    self.send_data({'play_again':False})
-                    self.send_data({'DISCONNECT':self.DISCONNECT_MESSAGE, 'disconnect_sent_to_end_game':True})
                     self.game_over_event.set()
-                    self._print_result("game")                   
+                    self._print_result("game")                  
+                    try:
+                        self.send_data({'play_again':False})
+                        self.send_data({'DISCONNECT':self.DISCONNECT_MESSAGE, 'disconnect_sent_to_end_game':True})
+                    except socket.error as e:
+                        error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                        self._set_up_to_terminate_program(error_msg)
+
                     playing = False
                     break
                 else:
@@ -265,16 +353,25 @@ class Client:
     def play_game(self): 
 
         main_game_thread = Thread()
+        main_game_thread.daemon = True
         main_game_thread.start()
 
         main_game_started = False
 
         full_msg = b''
         new_msg = True
-        while True:
-            #TODO: Catch exception when receiving and sending msg fails 
-            msg = self.client.recv(16)
-            if not msg: #  This breaks out of the loop when disconnect msg has been sent to server and client conn has been closed
+        while True:            
+            try:
+                msg = self.client.recv(16)
+            except ConnectionResetError as e: #  This exception is caught when the client tries to receive a msg from a disconnected server
+                error_msg = colored(f"Connection Reset: {e}", "red", attrs=['bold'])
+                self._set_up_to_terminate_program(error_msg, main_game_thread=main_game_thread, main_game_started=main_game_started)
+                break
+            except socket.error as e:
+                error_msg = colored(f"Error receiving data: {e}", "red", attrs=['bold'])
+                self._set_up_to_terminate_program(error_msg, main_game_thread=main_game_thread, main_game_started=main_game_started)
+                break
+            if not msg: #  This breaks out of the loop when disconnect msg has been sent to server and client conn has been closed server-side
                 break
             
             if new_msg:
@@ -291,8 +388,6 @@ class Client:
 
                 self.loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])                  
 
-                self.new_msg_received.set()
-
                 # NOTE Calling .join on self.loading_thread ensures that the spinner function has completed 
                 # NOTE (and finished using stdout) before attempting to print anything else to stdout.
                 # NOTE The first time .join is called, it joins the self.loading_thread instantiated 
@@ -303,123 +398,129 @@ class Client:
 
                 self.loading_thread.join() 
 
-                self.new_msg_received.clear() #  Clears the event so that it can be set in the next run of the loop.
                 # print("Loaded_json", self.loaded_json)                                       
 
                 new_msg = True
                 full_msg = b''
                 try:
-                    if "id" in self.loaded_json:
-                        self.ID = self.loaded_json["id"]
-                        loading_msg = "Both clients connected. Starting game"
-                        self.send_data({'id':self.ID})
-                        self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg,))
-                        self.loading_thread.start()                                                                        
-                    if "other_client_disconnected" in self.loaded_json: 
-                        self.other_client_disconnected.set()
-                        with self.condition:
-                            self.condition.notify()                        
-                        main_game_thread.join()                        
-                        
-                        if not self.game_ended.is_set() and not self.game_over_event.is_set():
-                            disconnect_msg = colored(self.loaded_json['other_client_disconnected'], "red", attrs=['bold'])
-                            print(f"\n{disconnect_msg}\n")
-                            if main_game_started:                             
-                                # If main_game_started is True, Player objects have non-empty values 
-                                # and can be safely accessed in _print_result() function. 
-                                # Also, there's no need to print results if the round did not start at all
-                                self._print_result("round")
-                                self._print_result("game")
+                    try:
+                        if "id" in self.loaded_json:
+                            self.ID = self.loaded_json["id"]
+                            loading_msg = "Both clients connected. Starting game"
+                            self.send_data({'id':self.ID})
+                            self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg, self.loaded_json, ))
+                            self.loading_thread.start()                                                                        
+                        if "other_client_disconnected" in self.loaded_json: 
+                            self.other_client_disconnected.set()
+                            with self.condition:
+                                self.condition.notify()                        
+                            main_game_thread.join()                        
+                            
+                            if not self.game_ended.is_set() and not self.game_over_event.is_set():
+                                disconnect_msg = colored(self.loaded_json['other_client_disconnected'], "red", attrs=['bold'])
+                                print(f"\n{disconnect_msg}\n")
+                                if main_game_started:                             
+                                    # If main_game_started is True, Player objects have non-empty values 
+                                    # and can be safely accessed in _print_result() function. 
+                                    # Also, there's no need to print results if the round did not start at all
+                                    self._print_result("round")
+                                    self._print_result("game")
 
 
-                        self.send_data(self.loaded_json)
+                            self.send_data(self.loaded_json)
 
-                        if self.game_over_event.is_set(): #  Do not listen for more msgs if disconnect msg has been sent
+                            if self.game_over_event.is_set(): #  Do not listen for more msgs if disconnect msg has been sent
+                                break
+
+                            # Continues listening for msgs, next msg would be the "waiting for other player to join the connection" status msg
+                            # Therefore the cycle repeats itself as game starts afresh if another player joins the connection before timeout
+                            continue 
+                        elif "status" in self.loaded_json:                                                          
+                            loading_msg = self.loaded_json['status'] 
+                            main_game_started = False #  Set value to False as game setup has begun again or as game is being set up for the first time
+                            if self.game_ended.is_set():
+                                main_game_thread.join() #  Make sure main_game_thread has ended before starting process of setting up game again
+                            self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg, self.loaded_json, ))
+                            self.loading_thread.start()               
+                        elif "waiting-for-name" in self.loaded_json:
+                            loading_msg = self.loaded_json['waiting-for-name']                                        
+                            self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg, self.loaded_json, ))
+                            self.loading_thread.start()
+                        elif "get-first-player-name" in self.loaded_json:                                                               
+                            connect4game._about_game()                        
+                            self.you = connect4game._get_player_name()
+                            self.send_data({'you':self.you})
+                            loading_msg = "Waiting for other player to enter their name"
+                            self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg, self.loaded_json, ))
+                            self.loading_thread.start()                        
+                        elif "opponent" in self.loaded_json:                                                             
+                            self.opponent = self.loaded_json['opponent']
+                            if not self.you:
+                                connect4game._about_game()
+                                self.you = self._get_other_player_name(self.opponent)
+                                self.send_data({'you':self.you})                        
+                            print("You are up against: ", self.opponent)                        
+                            # Shuffling player names
+                            if not self.ID:
+                                first_player = connect4game._shuffle_players([self.you, self.opponent])
+                                self.send_data({'first':first_player})                      
+                        elif "first" in self.loaded_json:
+                            first = self.loaded_json['first'][0]
+                            if self.ID:
+                                print("Randomly choosing who to go first . . .")                    
+                                print(f"{first} goes first")
+                            if first == self.you:
+                                colors = connect4game._get_players_colors(self.you)
+                                self.send_data({'colors':colors})
+                            else:
+                                loading_msg = f"Waiting for {self.opponent} to choose their color"
+                                self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg, self.loaded_json, ))
+                                self.loading_thread.start()                            
+                        elif "colors" in self.loaded_json:                                                                                     
+                            colors = self.loaded_json['colors']                        
+                            if first == self.you:
+                                self.your_turn = True
+                                self.player = Player(self.you, colored('O', colors[0], attrs=['bold']))                            
+                            else:
+                                self.your_turn = False
+                                self.player = Player(self.you, colored('O', colors[1], attrs=['bold']))                        
+                            self.send_data({'opponent_player_object':self.player})
+                        elif "opponent_player_object" in self.loaded_json:
+                            self.opponent = self.loaded_json['opponent_player_object']                        
+                            main_game_thread = Thread(target=self.main_game_thread)
+                            main_game_thread.daemon = True
+                            with self.condition:
+                                main_game_thread.start()
+                            main_game_started = True
+                            self.game_ended.clear()               
+                        elif "board" in self.loaded_json:
+                            self.board = self.loaded_json['board']
+                            self.board_updated_event.set() 
+                            with self.condition:
+                                self.condition.notify()
+                        elif 'play_again' in self.loaded_json:
+                            self.play_again_reply_received.set()                        
+                            with self.condition:
+                                self.condition.notify()
+                        elif 'first_player' in self.loaded_json:
+                            self.first_player_received.set()
+                            with self.condition:
+                                self.condition.notify()
+                        elif 'timeout' in self.loaded_json:
+                            print(colored(self.loaded_json['timeout'], "red", attrs=['bold']))
                             break
-
-                        # Continues listening for msgs, next msg would be the "waiting for other player to join the connection" status msg
-                        # Therefore the cycle repeats itself as game starts afresh if another player joins the connection before timeout
-                        continue 
-                    elif "status" in self.loaded_json:                                                          
-                        loading_msg = self.loaded_json['status'] 
-                        main_game_started = False #  Set value to False as game setup has begun again or as game is being set up for the first time
-                        if self.game_ended.is_set():
-                            main_game_thread.join() #  Make sure main_game_thread has ended before starting process of setting up game again
-                        self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg,))
-                        self.loading_thread.start()               
-                    elif "waiting-for-name" in self.loaded_json:
-                        loading_msg = self.loaded_json['waiting-for-name']                                        
-                        self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg,))
-                        self.loading_thread.start()
-                    elif "get-first-player-name" in self.loaded_json:                                                               
-                        connect4game._about_game()                        
-                        self.you = connect4game._get_player_name()
-                        self.send_data({'you':self.you})
-                        loading_msg = "Waiting for other player to enter their name"
-                        self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg,))
-                        self.loading_thread.start()                        
-                    elif "opponent" in self.loaded_json:                                                             
-                        self.opponent = self.loaded_json['opponent']
-                        if not self.you:
-                            connect4game._about_game()
-                            self.you = self._get_other_player_name(self.opponent)
-                            self.send_data({'you':self.you})                        
-                        print("You are up against: ", self.opponent)                        
-                        # Shuffling player names
-                        if not self.ID:
-                            first_player = connect4game._shuffle_players([self.you, self.opponent])
-                            self.send_data({'first':first_player})                      
-                    elif "first" in self.loaded_json:
-                        first = self.loaded_json['first'][0]
-                        if self.ID:
-                            print("Randomly choosing who to go first . . .")                    
-                            print(f"{first} goes first")
-                        if first == self.you:
-                            colors = connect4game._get_players_colors(self.you)
-                            self.send_data({'colors':colors})
-                        else:
-                            loading_msg = f"Waiting for {self.opponent} to choose their color"
-                            self.loading_thread = Thread(target=self.simulate_loading_with_spinner, args=(loading_msg,))
-                            self.loading_thread.start()                            
-                    elif "colors" in self.loaded_json:                                                                                     
-                        colors = self.loaded_json['colors']                        
-                        if first == self.you:
-                            self.your_turn = True
-                            self.player = Player(self.you, colored('O', colors[0], attrs=['bold']))                            
-                        else:
-                            self.your_turn = False
-                            self.player = Player(self.you, colored('O', colors[1], attrs=['bold']))                        
-                        self.send_data({'opponent_player_object':self.player})
-                    elif "opponent_player_object" in self.loaded_json:
-                        self.opponent = self.loaded_json['opponent_player_object']                        
-                        main_game_thread = Thread(target=self.main_game_thread)
-                        main_game_thread.daemon = True
-                        with self.condition:
-                            main_game_thread.start()
-                        main_game_started = True
-                        self.game_ended.clear()               
-                    elif "board" in self.loaded_json:
-                        self.board = self.loaded_json['board']
-                        self.board_updated_event.set() 
-                        with self.condition:
-                            self.condition.notify()
-                    elif 'play_again' in self.loaded_json:
-                        self.play_again_reply_received.set()                        
-                        with self.condition:
-                            self.condition.notify()
-                    elif 'first_player' in self.loaded_json:
-                        self.first_player_received.set()
-                        with self.condition:
-                            self.condition.notify()
-                    elif 'timeout' in self.loaded_json:
-                        print(colored(self.loaded_json['timeout'], "red", attrs=['bold']))
+                    except KeyError:
+                        self.send_data({'DISCONNECT':self.DISCONNECT_MESSAGE})                   
                         break
-                except KeyError:
-                    self.send_data({'DISCONNECT':self.DISCONNECT_MESSAGE})                   
-                    break            
+                except socket.error as e:
+                    error_msg = colored(f"Error sending data: {e}", "red", attrs=['bold'])
+                    self._set_up_to_terminate_program(error_msg, main_game_thread=main_game_thread, main_game_started=main_game_started)
+                    break         
 
         if self.game_over_event.is_set():
             main_game_thread.join() #  Wait for main_game_thread thread to end before printing
+
+        self.client.close()
         print(f"\nDisconnected\n")
 
                 # -------------------------------------Use loaded json data here-------------------------------------

--- a/client.py
+++ b/client.py
@@ -128,7 +128,12 @@ class Client:
             print(f"You have {self.player.points} points")
             print(f"{self.opponent.name} has {self.opponent.points} points\n\n")
         elif round_or_game == "game":
-            print(f"At the end of the game, after {self.level.current_level} rounds,")
+            
+            if self.level.current_level == 1:
+                print(f"At the end of the game,")
+            else:
+                print(f"At the end of the game, after {self.level.current_level} rounds,")
+                
             connect4game._calculate_and_display_final_result([self.player, self.opponent])
             print("Thanks for playing\n")
 
@@ -317,9 +322,8 @@ class Client:
                         main_game_thread.join()                        
                         
                         if not self.game_ended.is_set() and not self.game_over_event.is_set():
-                            print("\n")
-                            print(colored(self.loaded_json['other_client_disconnected'], "red", attrs=['bold']))
-                            print("\n")
+                            disconnect_msg = colored(self.loaded_json['other_client_disconnected'], "red", attrs=['bold'])
+                            print(f"\n{disconnect_msg}\n")
                             if main_game_started:                             
                                 # If main_game_started is True, Player objects have non-empty values 
                                 # and can be safely accessed in _print_result() function. 

--- a/server.py
+++ b/server.py
@@ -29,7 +29,8 @@ class Server:
         self.DISCONNECT_MESSAGE = "!DISCONNECT"
         try:
            self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        except socket.error as msg:
+        except socket.error as e:
+            print(f"Error creating socket: {e}")
             self.server = None
 
         self.TIMEOUT_FOR_CLIENT = 20
@@ -38,6 +39,7 @@ class Server:
     def host_game(self):
         try:
             self.server.bind(self.ADDR)
+            self.server.listen()
         except socket.error as e:
             self.server.close()
             self.server = None
@@ -53,14 +55,13 @@ class Server:
         data = bytes(f'{len(data):<{self.HEADERSIZE}}', self.FORMAT) + data
         try:
             conn.send(data)
-        except OSError as err:
-            raise err
+        except socket.error as e:
+            print(f"Error sending data: {e}")
 
 
     def start(self):
         global clients
         print("[STARTING] server is starting...")
-        self.server.listen(2)
         print(f"[LISTENING] server is listening on {self.SERVER}")
         self.start_game_when_two_clients_thread = threading.Thread(target=self.start_game_when_two_clients)
         self.start_game_when_two_clients_thread.start()
@@ -149,100 +150,98 @@ class Server:
 
         while True:
             try:
+                msg = conn.recv(16)   
+            except ConnectionResetError as e: #  This exception is caught when the client tries to receive a msg from a disconnected client
+                print(f"Connection Reset: {e}")
+                if conn == conn1:
+                    self.send_data(conn2, {"other_client_disconnected":"Other client disconnected unexpectedly"})
+                else:
+                    self.send_data(conn1, {"other_client_disconnected":"Other client disconnected unexpectedly"})
+                self.remove_client(conn, addr)
+                break
+            except socket.error as e:
+                print(f"Error receiving data: {e}")
+                            
+
+            if not msg:
+                self.remove_client(conn, addr)
+                break
+
+            if new_msg:
+                msglen = int(msg[:self.HEADERSIZE])
+                new_msg = False
+
+
+            full_msg += msg
+
+            if len(full_msg)-self.HEADERSIZE == msglen:
+                # ----------------Use loaded json data here----------------
+
+                loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])
+                # print("loaded_json: ",  loaded_json)
+                new_msg = True
+                full_msg = b''     
                 try:
-                    msg = conn.recv(16)   
-                except ConnectionResetError as e: #  This exception is caught when the client tries to receive a msg from a disconnected client
-                    print(f"Connection Reset: {e}")
-                    if conn == conn1:
-                        self.send_data(conn2, {"other_client_disconnected":"Other client disconnected unexpectedly"})
-                    else:
-                        self.send_data(conn1, {"other_client_disconnected":"Other client disconnected unexpectedly"})
-                    self.remove_client(conn, addr)
-                    break
-                               
-
-                if not msg:
-                    self.remove_client(conn, addr)
-                    break
-
-                if new_msg:
-                    msglen = int(msg[:self.HEADERSIZE])
-                    new_msg = False
-
-
-                full_msg += msg
-
-                if len(full_msg)-self.HEADERSIZE == msglen:
-                    # ----------------Use loaded json data here----------------
-
-                    loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])
-                    # print("loaded_json: ",  loaded_json)
-                    new_msg = True
-                    full_msg = b''     
-                    try:
-                        if 'id' in loaded_json:
-                            id = loaded_json['id']
-                            if not id: #  If id is 0 i.e. if first connected player...
-                                self.send_data(conn, {"get-first-player-name":True})
+                    if 'id' in loaded_json:
+                        id = loaded_json['id']
+                        if not id: #  If id is 0 i.e. if first connected player...
+                            self.send_data(conn, {"get-first-player-name":True})
+                        else:
+                            self.send_data(conn, {"waiting-for-name":"Waiting for other player to enter their name"})
+                    elif 'you' in loaded_json:
+                        you = loaded_json['you']
+                        if conn == conn1:
+                            self.send_data(conn2, {'opponent':you})
+                        elif conn == conn2:
+                            self.send_data(conn1, {'opponent':you})                        
+                    elif 'first' in loaded_json:
+                        self.send_data(conn1, {'first':loaded_json['first']})                        
+                        self.send_data(conn2, {'first':loaded_json['first']})
+                    elif 'colors' in loaded_json:
+                        self.send_data(conn1, {'colors':loaded_json['colors']})
+                        self.send_data(conn2, {'colors':loaded_json['colors']})
+                    elif 'opponent_player_object' in loaded_json:
+                        if conn == conn1:
+                            self.send_data(conn2, {'opponent_player_object':loaded_json['opponent_player_object']})
+                        elif conn == conn2:
+                            self.send_data(conn1, {'opponent_player_object':loaded_json['opponent_player_object']})                                            
+                    elif 'board' in loaded_json:
+                        if conn == conn1:
+                            self.send_data(conn2, {'board':loaded_json['board']})                            
+                        elif conn == conn2:
+                            self.send_data(conn1, {'board':loaded_json['board']})  
+                    elif 'round_over' in loaded_json:
+                        self.send_data(conn1, loaded_json)
+                        self.send_data(conn2, loaded_json)
+                    elif 'play_again' in loaded_json:
+                        try:
+                            if conn == conn1:
+                                self.send_data(conn2, {'play_again':loaded_json['play_again']})
+                            elif conn == conn2:
+                                self.send_data(conn1, {'play_again':loaded_json['play_again']})
+                        except OSError: # Other client may have disconnected already so sending data to it will raise OSError exception
+                            continue
+                    elif 'first_player' in loaded_json:                        
+                        self.send_data(conn1, {'first_player':loaded_json['first_player']})                        
+                        self.send_data(conn2, {'first_player':loaded_json['first_player']})
+                    elif 'wait_for_new_client' in loaded_json:
+                        self.start_game_when_two_clients_thread = threading.Thread(target=self.start_game_when_two_clients)
+                        self.start_game_when_two_clients_thread.start()
+                        break
+                    elif 'other_client_disconnected' in loaded_json:
+                        break
+                    elif 'DISCONNECT' in loaded_json:
+                        if loaded_json['DISCONNECT'] == self.DISCONNECT_MESSAGE:                            
+                            if 'disconnect_sent_to_end_game' in loaded_json and len(clients) == 2:
+                                self.remove_client(conn, addr, start_new_game=False)
                             else:
-                                self.send_data(conn, {"waiting-for-name":"Waiting for other player to enter their name"})
-                        elif 'you' in loaded_json:
-                            you = loaded_json['you']
-                            if conn == conn1:
-                                self.send_data(conn2, {'opponent':you})
-                            elif conn == conn2:
-                                self.send_data(conn1, {'opponent':you})                        
-                        elif 'first' in loaded_json:
-                            self.send_data(conn1, {'first':loaded_json['first']})                        
-                            self.send_data(conn2, {'first':loaded_json['first']})
-                        elif 'colors' in loaded_json:
-                            self.send_data(conn1, {'colors':loaded_json['colors']})
-                            self.send_data(conn2, {'colors':loaded_json['colors']})
-                        elif 'opponent_player_object' in loaded_json:
-                            if conn == conn1:
-                                self.send_data(conn2, {'opponent_player_object':loaded_json['opponent_player_object']})
-                            elif conn == conn2:
-                                self.send_data(conn1, {'opponent_player_object':loaded_json['opponent_player_object']})                                            
-                        elif 'board' in loaded_json:
-                            if conn == conn1:
-                                self.send_data(conn2, {'board':loaded_json['board']})                            
-                            elif conn == conn2:
-                                self.send_data(conn1, {'board':loaded_json['board']})  
-                        elif 'round_over' in loaded_json:
-                            self.send_data(conn1, loaded_json)
-                            self.send_data(conn2, loaded_json)
-                        elif 'play_again' in loaded_json:
-                            try:
-                                if conn == conn1:
-                                    self.send_data(conn2, {'play_again':loaded_json['play_again']})
-                                elif conn == conn2:
-                                    self.send_data(conn1, {'play_again':loaded_json['play_again']})
-                            except OSError: # Other client may have disconnected already so sending data to it will raise OSError exception
-                                continue
-                        elif 'first_player' in loaded_json:                        
-                            self.send_data(conn1, {'first_player':loaded_json['first_player']})                        
-                            self.send_data(conn2, {'first_player':loaded_json['first_player']})
-                        elif 'wait_for_new_client' in loaded_json:
-                            self.start_game_when_two_clients_thread = threading.Thread(target=self.start_game_when_two_clients)
-                            self.start_game_when_two_clients_thread.start()
+                                self.remove_client(conn, addr)
                             break
-                        elif 'other_client_disconnected' in loaded_json:
-                            break
-                        elif 'DISCONNECT' in loaded_json:
-                            if loaded_json['DISCONNECT'] == self.DISCONNECT_MESSAGE:                            
-                                if 'disconnect_sent_to_end_game' in loaded_json and len(clients) == 2:
-                                    self.remove_client(conn, addr, start_new_game=False)
-                                else:
-                                    self.remove_client(conn, addr)
-                                break
-                    except KeyError:
-                        self.remove_client(conn, addr)
-                        break                          
+                except KeyError:
+                    self.remove_client(conn, addr)
+                    break               
                         # ----------------Use loaded json data here----------------
-            except OSError as e: #  This exception is caught when the current client tries to send a msg to a disconnected client
-                print(f"OS Error Occured: {e}")
-                self.send_data(conn, {"other_client_disconnected":"Other client disconnected unexpectedly"})
-                     
+            
 
 
         


### PR DESCRIPTION
- Pluralize 'round' if self.level.current_level is greater than 1
- Print new lines at start and end of disconnect msg on same line
- Handle server.py closing unexpectedly in client.py
- Handle more socket.error exceptions on server
- Change back from event notifying spinner thread to notifying with change btw loaded_json and self.loaded_json (to test if using the event method is the cause of a subtle bug that causes the your_turn value to not change thereby causing one of the clients to hang, the other client hangs too because they never recieve the board with the other player's move)
- Close client client-side explicitly at the end of the play_game thread instead of relying on the GIL
- Modify spinner thread to change the color of loaded_json to red when an exception occurs (when end_thread_event is set) and terminate
- Change _wait_for_two_events to _wait_for_one_of_multiple_events since function waits for one of three events currently
- Print game stats and exception error msg and terminate program when socket.error exception occurs
- Remove backlog argument from socket .listen method as backlog does not mean the number of allowed connections