### PR TITLE
feat: Use locks to prevent race conditions with 'clients' and 'loaded_json'

### DIFF
--- a/server.py
+++ b/server.py
@@ -15,8 +15,6 @@ connect4game = Connect4Game()
 to_shuffle = threading.Event()
 to_shuffle.set()
 
-clients: List = []
-
 
 class Server:
     def __init__(self):
@@ -27,6 +25,12 @@ class Server:
         self.ADDR = (self.SERVER, self.PORT)
         self.FORMAT = 'utf-8'
         self.DISCONNECT_MESSAGE = "!DISCONNECT"
+        self.conn = None
+        self.addr = None
+
+        self.clients: List = []
+        self.clients_lock = threading.RLock()
+
         try:
            self.server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         except socket.error as e:
@@ -51,16 +55,25 @@ class Server:
             self.start()
 
     def send_data(self, conn, data):
+        copy_data = copy.copy(data)
         data = pickle.dumps(data)
         data = bytes(f'{len(data):<{self.HEADERSIZE}}', self.FORMAT) + data
         try:
             conn.send(data)
-        except socket.error:
-            raise
+        except socket.error as e:
+            print(f"Error sending '{copy_data}': {e}")
+            if conn != self.conn: 
+                opponent_conn, opponent_addr = self.opponent_conn_and_addr
+                # This means if sender of msg is not the current client, data was being sent to the other client, 
+                # therefore, send other_client_disconnected msg to current client
+                self.send_data(self.conn, {"other_client_disconnected":"An error occured with the other client"})
+                self.remove_client(opponent_conn, opponent_addr)
+            else:
+                self.remove_client(self.conn, self.addr)
+                raise # Only raise if it's the current client whose socket is closed or has trouble sending data so that this exception is caught in play_game thread
 
 
     def start(self):
-        global clients
         print("[STARTING] server is starting...")
         print(f"[LISTENING] server is listening on {self.SERVER}")
         self.start_game_when_two_clients_thread = threading.Thread(target=self.start_game_when_two_clients)
@@ -71,84 +84,98 @@ class Server:
                 conn, addr = self.server.accept()
             except OSError:
                 break
-            clients.append((conn, addr))
+            with self.clients_lock:
+                self.clients.append((conn, addr))
+            self.conn = conn
+            self.addr = addr
 
-            print(f"[ACTIVE CONNECTIONS] {len(clients)}")
+            with self.clients_lock:
+                print(f"[ACTIVE CONNECTIONS] {len(self.clients)}")
         print("[CLOSED] server is closed")
             
         
     def start_game_when_two_clients(self):
-        global clients
-        
-
         first_time_for_no_client = True
         first_time_for_one_client = True
         # lock = threading.Lock()
 
         while True: # Busy wait
-            if not clients:
+            self.clients_lock.acquire()
+            if not self.clients:
+                self.clients_lock.release()
                 if first_time_for_no_client:
                     print("Waiting for clients to join the connection. . .")
                     first_time_for_no_client = False #  Set to False so that print statement prints only once
                     first_time_for_one_client = True
-                time.sleep(1) #  Sleep if not clients
+                time.sleep(1) #  Sleep if not self.clients
                 continue
-            elif len(clients) == 1:
-                conn, addr = clients[0]
+            elif len(self.clients) == 1:
+                conn, addr = self.clients[0]
+                self.clients_lock.release()
                 if first_time_for_one_client:
                     start_time = time.time()
                     print("Waiting for other player to join the connection. . .")
-                    self.send_data(conn, {"status":"Waiting for other player to join the connection"})
+                    try:
+                        self.send_data(conn, {"status":"Waiting for other player to join the connection"})
+                    except socket.error:
+                        self.remove_client(conn, addr)
                     first_time_for_one_client = False #  Set to False so that print statement prints only once and msg is sent only once
                     first_time_for_no_client = True
                 if time.time() > start_time + self.TIMEOUT_FOR_CLIENT:
                     print("Connection timed out: No other player joined the game. Try joining the connection again.")
-                    self.send_data(conn, {"timeout":"Connection timed out: No other player joined the game. Try joining the connection again."})
+                    try:
+                        self.send_data(conn, {"timeout":"Connection timed out: No other player joined the game. Try joining the connection again."})
+                    except socket.error:
+                        self.remove_client(conn, addr)
                     self.remove_client(conn, addr)
                 time.sleep(1) #  Sleep if one client
                 continue
-            elif len(clients) == 2:                           
+            elif len(self.clients) == 2:                           
                 print("Both clients connected. Starting game. . .")
-                for client in clients:
+                for client in self.clients:
                     conn, addr = client
 
                     thread = threading.Thread(target=self.play_game, args=(conn, addr))
                     thread.start()                   
+                self.clients_lock.release()
                 break
-            
 
     def remove_client(self, conn, addr, start_new_game=True):
-        global clients
-        print("Lost connection")
-        print(f"[DISCONNECTION] {addr} disconnected.")
-        try:
-            clients.remove((conn, addr))
-        except ValueError:
-            pass
-        try:      
-            conn.close()
-        except socket.error:
-            raise
+        conn.close()
+
+        with self.clients_lock:
+            try:
+                self.clients.remove((conn, addr))
+            except ValueError:
+                print("Client has already been removed from list")
+                return
+            else:
+                print(f"[DISCONNECTION] {addr} disconnected.")
+                print(f"Number of clients left: {len(self.clients)}")
 
         # Listen for new connection(s) after losing client only if the thread is not already running and if start_new_game is True
-        if not self.start_game_when_two_clients_thread.is_alive() and start_new_game and len(clients) != 2:
-            self.start_game_when_two_clients_thread = threading.Thread(target=self.start_game_when_two_clients)
-            self.start_game_when_two_clients_thread.start()
+        with self.clients_lock:
+            if not self.start_game_when_two_clients_thread.is_alive() and start_new_game and len(self.clients) != 2:
+                self.start_game_when_two_clients_thread = threading.Thread(target=self.start_game_when_two_clients)
+                self.start_game_when_two_clients_thread.start()
                 
 
     def play_game(self, conn, addr):
-        global clients
         self.start_game_when_two_clients_thread.join()
 
         print(f"[NEW CONNECTION] {addr} connected.")
 
-        conn1, addr1 = clients[0]
-        conn2, addr2 = clients[1]
-
-        if conn == conn1:
-            self.send_data(conn1, {"id": clients.index((conn1, addr1))})
-        else:
-            self.send_data(conn2, {"id": clients.index((conn2, addr2))})
+        with self.clients_lock:
+            conn1, addr1 = self.clients[0]
+            conn2, addr2 = self.clients[1]
+        
+        with self.clients_lock:
+            if conn == conn1:
+                self.opponent_conn_and_addr = self.clients[1]
+                self.send_data(conn1, {"id": self.clients.index((conn1, addr1))})
+            else:
+                self.opponent_conn_and_addr = self.clients[0]
+                self.send_data(conn2, {"id": self.clients.index((conn2, addr2))})
             
 
         full_msg = b''
@@ -227,40 +254,33 @@ class Server:
                             self.send_data(conn1, loaded_json)
                             self.send_data(conn2, loaded_json)
                         elif 'play_again' in loaded_json:
-                            try:
-                                if conn == conn1:
-                                    self.send_data(conn2, {'play_again':loaded_json['play_again']})
-                                elif conn == conn2:
-                                    self.send_data(conn1, {'play_again':loaded_json['play_again']})
-                            except OSError: # Other client may have disconnected already so sending data to it will raise OSError exception
-                                continue
+                            if conn == conn1:
+                                self.send_data(conn2, {'play_again':loaded_json['play_again']})
+                            elif conn == conn2:
+                                self.send_data(conn1, {'play_again':loaded_json['play_again']})                            
                         elif 'first_player' in loaded_json:                        
                             self.send_data(conn1, {'first_player':loaded_json['first_player']})                        
                             self.send_data(conn2, {'first_player':loaded_json['first_player']})
                         elif 'wait_for_new_client' in loaded_json:
+                            print("Waiting for new client so starting thread again")
                             self.start_game_when_two_clients_thread = threading.Thread(target=self.start_game_when_two_clients)
                             self.start_game_when_two_clients_thread.start()
                             break
                         elif 'other_client_disconnected' in loaded_json:
                             break
                         elif 'DISCONNECT' in loaded_json:
-                            if loaded_json['DISCONNECT'] == self.DISCONNECT_MESSAGE:                            
-                                if 'disconnect_sent_to_end_game' in loaded_json and len(clients) == 2:
-                                    self.remove_client(conn, addr, start_new_game=False)
-                                else:
-                                    self.remove_client(conn, addr)
+                            if loaded_json['DISCONNECT'] == self.DISCONNECT_MESSAGE:
+                                with self.clients_lock:                         
+                                    if 'disconnect_sent_to_end_game' in loaded_json and len(self.clients) == 2:
+                                        self.remove_client(conn, addr, start_new_game=False)
+                                    else:
+                                        self.remove_client(conn, addr)
                                 break
                     except KeyError:
                         self.remove_client(conn, addr)
                         break               
                             # ----------------Use loaded json data here----------------
-            except socket.error as e:
-                print(f"Error sending data: {e}")
-                if conn == conn1:
-                    self.send_data(conn2, {"other_client_disconnected":"An error occured with the other client"})
-                else:
-                    self.send_data(conn1, {"other_client_disconnected":"An error occured with the other client"})
-                self.remove_client(conn, addr)
+            except socket.error:
                 break
 
 


### PR DESCRIPTION
- Change clients from global to instance variable
- Handle exception caught when send_data fails in send_data method and if it is caught in play_game thread, terminate the listening loop
- Use lock to prevent race conditions when accessing the self.clients and self.loaded_json variables. RLock is used because while lock is acquired in a thread, it may also be acquired in called methods.
- Color all error msgs red in client.py
- Print error_msg/game_stats in _set_up_to_terminate_program only after waiting for threads to complete
- Rename reset_game to _reset_game (refactor)
- Send other_client_disconnected msg back to server only if game_ended or game_over_event is not set so that listening loop will not be terminated in server.py
- Notify current client if sending to other client fails i.e. other client has disconnected
- Do not catch OSError when sending play_again to other client since exception handling is now done in send_data method