### PR TITLE
fix: Raise custom exception to determine the sender of a msg that failed to send

### DIFF
--- a/client.py
+++ b/client.py
@@ -398,8 +398,8 @@ class Client:
                 
                 # -------------------------------------Use loaded json data here-------------------------------------
 
-                with self.loaded_json_lock:
-                    self.loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])                  
+                # with self.loaded_json_lock:
+                #     self.loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])                  
 
                 # NOTE Calling .join on self.loading_thread ensures that the spinner function has completed 
                 # NOTE (and finished using stdout) before attempting to print anything else to stdout.
@@ -411,8 +411,8 @@ class Client:
 
                 self.loading_thread.join() 
 
-                # with self.loaded_json_lock:
-                #     print("Loaded_json", self.loaded_json)                                       
+                with self.loaded_json_lock:
+                    print("Loaded_json", self.loaded_json)                                       
 
                 new_msg = True
                 full_msg = b''

--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,3 @@
+class SendingDataError(Exception):
+    """Exception raised when sending data fails.
+    """


### PR DESCRIPTION
- Raise custom exception to determine the sender of a msg that failed to send. Previously, instance variables conn, addr and opponent_conn_and_addr were used to keep track of current and other client in send_data method. This method is buggy because the instance variables' final values are those of the client who joins the connecton last. Instead, when the socket.error exception is caught in the send_data method, it raises a custom exception that returns which connection failed to send the data. This is the handled in the play_game thread