### PR TITLE
fix: Uncomment code commented out mistakenly in previous commit

### DIFF
--- a/client.py
+++ b/client.py
@@ -398,8 +398,8 @@ class Client:
                 
                 # -------------------------------------Use loaded json data here-------------------------------------
 
-                # with self.loaded_json_lock:
-                #     self.loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])                  
+                with self.loaded_json_lock:
+                    self.loaded_json = pickle.loads(full_msg[self.HEADERSIZE:])                  
 
                 # NOTE Calling .join on self.loading_thread ensures that the spinner function has completed 
                 # NOTE (and finished using stdout) before attempting to print anything else to stdout.
@@ -411,8 +411,8 @@ class Client:
 
                 self.loading_thread.join() 
 
-                with self.loaded_json_lock:
-                    print("Loaded_json", self.loaded_json)                                       
+                # with self.loaded_json_lock:
+                #     print("Loaded_json", self.loaded_json)                                       
 
                 new_msg = True
                 full_msg = b''

--- a/server.py
+++ b/server.py
@@ -76,6 +76,7 @@ class Server:
                 break
             with self.clients_lock:
                 self.clients.append((conn, addr))
+
                 print(f"[ACTIVE CONNECTIONS] {len(self.clients)}")
         print("[CLOSED] server is closed")
             
@@ -102,7 +103,7 @@ class Server:
                     print("Waiting for other player to join the connection. . .")
                     try:
                         self.send_data(conn, {"status":"Waiting for other player to join the connection"})
-                    except socket.error:
+                    except SendingDataError:
                         self.remove_client(conn, addr)
                     first_time_for_one_client = False #  Set to False so that print statement prints only once and msg is sent only once
                     first_time_for_no_client = True
@@ -110,7 +111,7 @@ class Server:
                     print("Connection timed out: No other player joined the game. Try joining the connection again.")
                     try:
                         self.send_data(conn, {"timeout":"Connection timed out: No other player joined the game. Try joining the connection again."})
-                    except socket.error:
+                    except SendingDataError:
                         self.remove_client(conn, addr)
                     self.remove_client(conn, addr)
                 time.sleep(1) #  Sleep if one client


### PR DESCRIPTION
- Raise custom exception to determine the sender of a msg that failed to send. Previously, instance variables conn, addr and opponent_conn_and_addr were used to keep track of current and other client in send_data method. This method is buggy because the instance variables' final values are those of the client who joins the connecton last. Instead, when the socket.error exception is caught in the send_data method, it raises a custom exception that returns which connection failed to send the data. This is the handled in the play_game thread