### PR TITLE
Collect IP address for server and fix some bugs

### DIFF
--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ class Server:
     def __init__(self):
         self.HEADERSIZE = 10
         self.SERVER = socket.gethostbyname(socket.gethostname())
-        # self.SERVER = "127.0.0.1" 5#  Uncomment this line to test on localhost
+        # self.SERVER = "127.0.0.1" #  Uncomment this line to test on localhost
         self.PORT = 5050
         self.ADDR = (self.SERVER, self.PORT)
         self.FORMAT = 'utf-8'
@@ -43,6 +43,18 @@ class Server:
         
 
     def host_game(self):
+
+        try:
+            ip = input("Enter the IP address of this machine or press Enter "
+                        f"to use {self.SERVER}\nTip - If you are having trouble with this, or you do not wish to use this IP, "
+                        "copy the IPv4 address of this machine and paste it here: ").strip()
+        except EOFError:
+            self.server = None
+        else:
+            if ip:
+                self.SERVER = ip
+                self.ADDR = (self.SERVER, self.PORT)
+
         try:
             self.server.bind(self.ADDR)
             self.server.listen()
@@ -75,8 +87,8 @@ class Server:
                 conn, addr = self.server.accept()
             except socket.timeout:
                 continue
-            except OSError:
-                break            
+            except socket.error as e:
+                break
 
             with self.clients_lock:
                 if len(self.clients) < 2: #  Continue with program only if number of clients connected is not yet two
@@ -134,9 +146,13 @@ class Server:
                         break
                 else:
                     break
-            elif len(self.clients) == 2:                           
+            elif len(self.clients) == 2:                         
                 self.new_client_event.clear()
                 print("Both clients connected. Starting game. . .")
+
+                with self.play_game_threads_lock:
+                    self.play_game_threads = [] #  Clear old threads stored in list
+
                 for client in self.clients:
                     conn, addr = client
 
@@ -207,7 +223,7 @@ class Server:
                 if thread.is_alive():
                     thread.join()
 
-        print("Keyboard Interrupt detected")
+        print(f"\nKeyboard Interrupt detected")
         print("[CLOSED] server is closed")
         sys.exit(1)
 


### PR DESCRIPTION
- A machine may have multiple IP addresses and so socket.gethostbyname(socket.gethostname()) may not fetch the one the user requires, for example, if they require the IP for their Wireless LAN adapter Wi-Fi instead. I have now added functionality for the user to manually input the IP address they wish to use in the process of hosting the server in server.py. This is already done for client.py.

-  I fixed a bug that caused the game stats to be printed when a game had not yet started. This bug arose when the [line](https://github.com/Winnie-Fred/Connect4/commit/584ed1e30e5afd98100fc0a9813f14bd334da5bf#diff-1ebfaf6cb3592166b73835fa82333cb7109e7c624865c0039a7b22ff34aa27faL562) that unset the event keeping track of whether a game had started was removed. Because the event was not being unset each time the client connected again in the same program, it remained set throughout the life of the program. Moving the line that creates the event (event is unset by default) to the _reset_game() function fixed this bug

- On calling terminate_program() on the Client class instance as opposed to catching KeyboardInterrupt twice like it was done in this [commit](https://github.com/Winnie-Fred/Connect4/commit/571047e7324d0095bb59e9b86607c05fe54d8856), a bug arose when input() was interrupted with Keyboard Interrupt because the self.client variable did not exist yet, hence .send() in terminate_program raised an exception. I fixed this bug by moving the self.client socket creation to the top of the connect_to_game() method. Input can now be interrupted and be terminated gracefully without traceback.