### PR TITLE
Add timeout for recv in server.py and terminate connection when it times out

### DIFF
--- a/board.py
+++ b/board.py
@@ -47,7 +47,7 @@ class Board:
     def play_at_position(self, player):
         choice = self._get_position(player)
         if choice is None:
-            return
+            return False
         for i, row in reversed(list(enumerate(self.grid))):
             if row[choice] == '':
                 row[choice] = player.marker
@@ -56,7 +56,8 @@ class Board:
                 if i == 0:
                     print("That column is full")
                     self.play_at_position(player) #  Call function again to take in another input
-                continue 
+                continue
+        return True 
 
     def _check_horizontal_win(self, player_marker):
         win_pattern = [player_marker] * 4

--- a/connect4.py
+++ b/connect4.py
@@ -28,7 +28,11 @@ class Connect4Game:
             "Points from each round will be added up at the end of the game.\n"
             "The overall winner of the game is the player with the most points at the end of the game.\n"
             "That's it. You are all set!\n")
-        input("Press Enter key to continue . . . ")
+        try:
+            input("Press Enter key to continue . . . ")
+        except EOFError:
+            return False
+        return True
 
 
     def _get_player_name(self):


### PR DESCRIPTION
- I added timeout for recv on server and disconnect both clients when it times out. This will prevent the conn from existing indefinitely but in particular, this will timeout half-open connections i.e. when only one side of the connection realizes the connection has been lost but the other side keeps waiting indefinitely.
- I also called connect_to_game from the main thread only so that the play_game thread can terminate
- To terminate gracefully, the main thread now waits for all threads to finish instead of play_game thread waiting
- I also handle EOFErrors before they can raise new exceptions in play_game and main_game_thread threads