### PR TITLE
Handle EOFErrors in a better way

### DIFF
--- a/board.py
+++ b/board.py
@@ -29,10 +29,8 @@ class Board:
 
     def _get_position(self, player):
         while True:
-            try:
-                choice = input(f"{player.name} {player.marker}, enter the position you want to play at between 0 and 6: ")
-            except EOFError:
-                return
+            choice = input(f"{player.name} {player.marker}, enter the position you want to play at between 0 and 6: ")
+           
             try:
                 choice = int(choice)
                 if not choice in range(0, 7):
@@ -45,9 +43,7 @@ class Board:
 
 
     def play_at_position(self, player):
-        choice = self._get_position(player)
-        if choice is None:
-            return False
+        choice = self._get_position(player)        
         for i, row in reversed(list(enumerate(self.grid))):
             if row[choice] == '':
                 row[choice] = player.marker

--- a/connect4.py
+++ b/connect4.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from random import shuffle
 
 from termcolor import colored  # type: ignore
@@ -28,19 +29,14 @@ class Connect4Game:
             "Points from each round will be added up at the end of the game.\n"
             "The overall winner of the game is the player with the most points at the end of the game.\n"
             "That's it. You are all set!\n")
-        try:
-            input("Press Enter key to continue . . . ")
-        except EOFError:
-            return False
-        return True
+        input("Press Enter key to continue . . . ")
+        
 
 
     def _get_player_name(self):
         while True:
-            try:
-                one_player = input("Enter your name: ").strip()
-            except EOFError:
-                return
+            one_player = input("Enter your name: ").strip()
+            
             if one_player:
                 break
             print("You must enter a name")
@@ -49,10 +45,7 @@ class Connect4Game:
     def _get_other_player_name(self, player):
 
         while True:
-            try:
-                other_player = input("Enter other player's name: ").strip()
-            except EOFError:
-                return                
+            other_player = input("Enter other player's name: ").strip()                           
             if other_player.lower() == player.lower():
                 print("A player already exists with that name. Choose another name")
                 continue
@@ -74,10 +67,8 @@ class Connect4Game:
 
     def _get_players_colors(self, player):
         while True:
-            try:
-                color = input(f"{player}, Choose a color for your token between Red and Blue. Enter 'R' for Red or 'B' for Blue: ")
-            except EOFError:
-                return
+            color = input(f"{player}, Choose a color for your token between Red and Blue. Enter 'R' for Red or 'B' for Blue: ")
+            
             if color.lower() == 'r':
                 return ('red', 'blue')
             if color.lower() == 'b':
@@ -146,10 +137,8 @@ class Connect4Game:
             print(f"{player_two.name} has {player_two.points} points\n\n")
 
             while True:
-                try:
-                    play_again = input("Want to play another round? Enter 'Y' for 'yes' and 'N' for 'no': ").lower().strip()
-                except EOFError:
-                    return
+                play_again = input("Want to play another round? Enter 'Y' for 'yes' and 'N' for 'no': ").lower().strip()
+                
                 if play_again == 'y':
                     # Shuffle the players again before starting next round.
                     self.level.current_level += 1
@@ -167,4 +156,11 @@ class Connect4Game:
         
 if __name__ == "__main__":
     connect4game = Connect4Game()
-    connect4game.play_game()
+    try:
+        connect4game.play_game()
+    except EOFError:
+        print("An EOFError occured. Closing program")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("Keyboard Interrupt detected. Closing program")
+        sys.exit(1)


### PR DESCRIPTION
- I previously used a very ugly method to handle EOFErrors by making methods that raised them return None or Booleans. I then checked for NoneType and Booleans in play_game thread to break out of the listening loop. Doing it this way caused more lines of code and more room for errors (and for the first version of the project, kept the program running without input).
- I also fixed a bug that happened sometimes when Keyboard Interrupt interrupted this [method](https://github.com/Winnie-Fred/Connect4/blob/a2c7baa39aed2191171de1e322e3413c6c5211f0/client.py#L294). It caused the program to crash badly because some daemon threads were still running. This happened because the main_game_thread thread was trying to print game stats but the Keyboard Interrupt terminated the program before it could finish. This was solved by waiting on threads with a new method "wait_for_threads" before quitting the program.